### PR TITLE
Fix: Remove the error code

### DIFF
--- a/feedback-examples/algorithmic-feedback/algorithmic_feedback.ipynb
+++ b/feedback-examples/algorithmic-feedback/algorithmic_feedback.ipynb
@@ -214,7 +214,7 @@
         "            \"coleman_liau_index\",\n",
         "            \"automated_readability_index\",\n",
         "        ]\n",
-        "        metrics = {fn: getattr(textstat, fn)(text) for fn in fns for fn in fns}\n",
+        "        metrics = {fn: getattr(textstat, fn)(text) for fn in fns}\n",
         "        for key, value in metrics.items():\n",
         "            client.create_feedback(\n",
         "                run.id,\n",


### PR DESCRIPTION
The phrase for fn in fns is repeated twice in the list comprehension, which is unnecessary. 